### PR TITLE
Capture output to show info

### DIFF
--- a/jupyterlab_requirements/dependency_management/customized_kernel.py
+++ b/jupyterlab_requirements/dependency_management/customized_kernel.py
@@ -61,6 +61,7 @@ class JupyterKernelHandler(APIHandler):
                 f". {kernel_name}/bin/activate && ipython kernel install --user"
                 f" --name={kernel_name} --display-name 'Python ({kernel_name})'",
                 shell=True,
+                capture_output=True,
                 cwd=complete_path
             )
             _LOGGER.info(process_output.stdout.decode("utf-8"))


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

```
Could not enter environment 'NoneType' object has no attribute 'decode'
```

## This introduces a breaking change

- [ ] Yes
- [x] No
