### PR TITLE
Fix no kernel issue

### DIFF
--- a/src/components/dependencyManagementUI.tsx
+++ b/src/components/dependencyManagementUI.tsx
@@ -242,7 +242,12 @@ export class DependenciesManagementUI extends React.Component<IDependencyManagem
 
     setKernelName(event: React.ChangeEvent<HTMLInputElement>) {
 
-      const kernel_name = event.target.value
+      var kernel_name = event.target.value
+
+      if ( event.target.value == "python3" ) {
+        console.warn('kernel_name python3 cannot be used assigning default one')
+        var kernel_name = "jupyterlab-requirements"
+      }
 
       this.setState(
         {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -290,9 +290,16 @@ export async function parse_inputs_from_metadata(
     initial_loaded_requirements_lock: RequirementsLock,
     initial_resolution_engine: string
 ): Promise<IDependencyManagementUIState> {
+    var kernel_name = ui_state.kernel_name
+
+    if ( ui_state.kernel_name == "python3" ) {
+        console.warn('kernel_name python3 cannot be used, assigning default one')
+        var kernel_name: string = "jupyterlab-requirements"
+    }
+
     const result = await _handle_thoth_config(
         initial_loaded_thoth_config,
-        ui_state.kernel_name,
+        kernel_name,
         ui_state.thoth_config,
         ui_state.recommendation_type,
         initial_resolution_engine
@@ -321,7 +328,7 @@ export async function parse_inputs_from_metadata(
  * Function: Retrieve installed packages from kernel.
  */
 
-async function retrieveInstalledPackages(kernel_name:string, packages: {}): Promise<{}> {
+async function retrieveInstalledPackages(kernel_name: string, packages: {}): Promise<{}> {
 
     // Retrieve installed packages
     const retrieved_packages = await discover_installed_packages( kernel_name )

--- a/src/notebook.ts
+++ b/src/notebook.ts
@@ -54,6 +54,11 @@ export function get_kernel_name( notebook: NotebookPanel ): string {
 
     console.debug('kernel_name identified:', kernel_name)
 
+    if ( kernel_name == "python3" ) {
+        console.warn('kernel_name python3 cannot be used, assigning default one')
+        return "jupyterlab-requirements"
+    }
+
     return kernel_name
 }
 


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Related-To: https://github.com/operate-first/support/issues/142#issuecomment-806246616
Fixes: https://github.com/thoth-station/jupyterlab-requirements/issues/225

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Introduce a mechanism to map kernel_name and prevent users from overwriting standard kernel 