### PR TITLE
Do not recreate kernel every time and automatically relock when a package is deleted

### DIFF
--- a/jupyterlab_requirements/dependency_management/pipenv.py
+++ b/jupyterlab_requirements/dependency_management/pipenv.py
@@ -50,7 +50,7 @@ class PipenvHandler(APIHandler):
         env_path = complete_path.joinpath(kernel_name)
 
         # Delete and recreate folder
-        if env_path.exists():
+        if not env_path.exists():
             _ = subprocess.call(
                 f"rm -rf ./{kernel_name} ", shell=True, cwd=complete_path)
 

--- a/jupyterlab_requirements/dependency_management/thoth.py
+++ b/jupyterlab_requirements/dependency_management/thoth.py
@@ -58,7 +58,7 @@ class ThothAdviseHandler(APIHandler):
         env_path = complete_path.joinpath(kernel_name)
 
         # Delete and recreate folder
-        if env_path.exists():
+        if not env_path.exists():
             _ = subprocess.call(
                 f"rm -rf ./{kernel_name} ", shell=True, cwd=complete_path)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab_requirements",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "JupyterLab Extension for dependency management and optimization",
   "keywords": [
     "jupyter",

--- a/src/components/dependencyManagementUI.tsx
+++ b/src/components/dependencyManagementUI.tsx
@@ -450,13 +450,13 @@ export class DependenciesManagementUI extends React.Component<IDependencyManagem
         _.get(packages_parsed, "new_packages")
       )
 
-      if ( _.get(deleted_case, "relock") == true ) {
+      if ( _.get(deleted_case, "action_required") == "relock" ) {
         await this.lock_using_thoth()
         return
       }
 
-      if ( _.get(deleted_case, "go_to_state") == true ) {
-        await this.setNewState(_.get(deleted_case, "new_state"));
+      if ( _.get(deleted_case, "action_required") == "go_to_state" ) {
+        await this.setNewState( _.get(deleted_case, "new_state" ) );
         return
       }
 
@@ -467,7 +467,7 @@ export class DependenciesManagementUI extends React.Component<IDependencyManagem
       )
 
       await this.setNewState(new_state);
-
+      return
     }
 
     async install() {
@@ -602,7 +602,7 @@ export class DependenciesManagementUI extends React.Component<IDependencyManagem
 
       await this.setNewState(ui_state);
       return
-  }
+    }
 
 
     async lock_using_pipenv () {
@@ -704,6 +704,7 @@ export class DependenciesManagementUI extends React.Component<IDependencyManagem
       )
 
       await this.setNewState(ui_on_start_state);
+      return
     }
 
     render(): React.ReactNode {
@@ -1080,7 +1081,14 @@ export class DependenciesManagementUI extends React.Component<IDependencyManagem
 
         case"ready":
 
-          this.props.panel.sessionContext.session.changeKernel({"name": this.state.kernel_name})
+          // Check if kernel name is already assigned to notebook and if yes, do nothing
+
+          if ( get_kernel_name( this.props.panel ) == this.state.kernel_name ) {
+            console.log("kernel name already set for the notebook, do not restart kernel...")
+          }
+          else {
+            this.props.panel.sessionContext.session.changeKernel({"name": this.state.kernel_name})
+          }
 
           return (
             <div>


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies
Fixes: https://github.com/thoth-station/jupyterlab-requirements/issues/220
Fixes: https://github.com/thoth-station/jupyterlab-requirements/issues/219

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

- Do not recreate the kernel every time if it exists already
- Do not restart the kernel unless the user changes it, otherwise variables saved are lost.
- Automatically relock when a package is deleted
