### PR TITLE
fix requirements files missing from source build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include LICENSE
 include README.md
 include pyproject.toml
 include setup.py
-
+include requirements.txt
 include package.json
 include install.json
 include ts*.json


### PR DESCRIPTION
fix requirements files missing from source build
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

source build fails as the requirements.txt is not included in sdist package https://pypi.org/project/jupyterlab-requirements/#files
and it is required in setup.py.

## This introduces a breaking change

- [x] No

## Description

This would allow the release module to include requirements.txt while releasing.
