### PR TITLE
Provide more info on errors to user

### DIFF
--- a/jupyterlab_requirements/dependency_management/base.py
+++ b/jupyterlab_requirements/dependency_management/base.py
@@ -127,11 +127,8 @@ class DependencyManagementBaseHandler(APIHandler):
                 self.set_status(202)
                 self.finish("{}")
             else:
-                if r[1]["error"]:
-                    self.set_status(500)
-                    _LOGGER.debug("%r", r)
-                else:
-                    self.set_status(200)
+                # We port errors to the frontend to show them to the user.
+                self.set_status(200)
                 self.finish(json.dumps(r[1]))
 
     def redirect_to_task(self, task_index: int):

--- a/jupyterlab_requirements/dependency_management/pipenv.py
+++ b/jupyterlab_requirements/dependency_management/pipenv.py
@@ -118,7 +118,7 @@ class PipenvHandler(DependencyManagementBaseHandler):
             returncode = 1
 
         if output.returncode != 0:
-            _LOGGER.warning("error locking dependencies using Pipenv: %r", output.stderr)
+            _LOGGER.warning("error in process trying to lock dependencies with pipenv: %r", output.stderr)
             result["error"] = True
             result["error_msg"] = str(output.stderr)
             returncode = 1

--- a/jupyterlab_requirements/dependency_management/thoth.py
+++ b/jupyterlab_requirements/dependency_management/thoth.py
@@ -107,7 +107,7 @@ class ThothAdviseHandler(DependencyManagementBaseHandler):
 
             if error_result:
                 advise["error"] = True
-                advise["error_msg"] = error_result
+                advise["error_msg"] = result.get("error_msg")
                 returncode = 1
 
             else:
@@ -127,7 +127,7 @@ class ThothAdviseHandler(DependencyManagementBaseHandler):
         except Exception as api_error:
             _LOGGER.warning(f"error locking dependencies using Thoth: {api_error}")
             advise["error"] = True
-            advise["error_msg"] = "Error locking dependencies, check pod logs for more details about the error."
+            advise["error_msg"] = f"Error locking dependencies, check pod logs for more details about the error."
             returncode = 1
 
         finally:

--- a/jupyterlab_requirements/dependency_management/thoth.py
+++ b/jupyterlab_requirements/dependency_management/thoth.py
@@ -127,7 +127,7 @@ class ThothAdviseHandler(DependencyManagementBaseHandler):
         except Exception as api_error:
             _LOGGER.warning(f"error locking dependencies using Thoth: {api_error}")
             advise["error"] = True
-            advise["error_msg"] = f"Error locking dependencies, check pod logs for more details about the error."
+            advise["error_msg"] = "Error locking dependencies, check pod logs for more details about the error."
             returncode = 1
 
         finally:

--- a/src/components/dependencyManagementUI.tsx
+++ b/src/components/dependencyManagementUI.tsx
@@ -223,7 +223,7 @@ export class DependenciesManagementUI extends React.Component<IDependencyManagem
       _.set(new_state, "thoth_resolution_error_msg", thoth_resolution_error_msg)
 
       _.set(new_state, "pipenv_resolution_error_msg", pipenv_resolution_error_msg)
-      
+
       console.debug("new", new_state)
       this.setState(new_state);
     }
@@ -1125,12 +1125,12 @@ export class DependenciesManagementUI extends React.Component<IDependencyManagem
 
         case "failed_re":
 
-          let paragrah_failure = <p> 
+          let paragrah_failure = <p>
             Thoth resolution engine failed because of: {this.state.thoth_resolution_error_msg} <br></br> <br></br>
               Pipenv resolution engine failed because of: {this.state.pipenv_resolution_error_msg}<br></br> <br></br>
               {this.state.error_msg} <br></br>
           </p>
-  
+
           return (
             <div>
               <div>


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/jupyterlab-requirements/issues/270
Fixes: https://github.com/thoth-station/jupyterlab-requirements/issues/273

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Provide more info to users when resolution engines fail.
