### PR TITLE
use thoth-advise manager instead of update manager

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -11,7 +11,7 @@ runtime_environments:
     recommendation_type: latest
 
 managers:
-  - name: update
+  - name: thoth-advise
     configuration:
       labels: [bot]
   - name: info


### PR DESCRIPTION
Switch from using update manager to using kebechet advise manager. This will be the first repository to switch to having its dependencies fully managed by Thoth, so keep an eye out for issues.
