### PR TITLE
Move kernel command to Kernel Menu Group

### DIFF
--- a/jupyterlab_requirements/dependency_management/magic_commands.py
+++ b/jupyterlab_requirements/dependency_management/magic_commands.py
@@ -212,7 +212,11 @@ class HorusMagics(Magics):
                 nb_path = os.getcwd() + f"/{str(nb_name)}"
 
             else:
-                raise Exception("Could not obtain notebook path from file. Please open issue with Thoth team!")
+                raise Exception(
+                    "Could not obtain notebook path from file. Please open issue in"
+                    " https://github.com/thoth-station/jupyterlab-requirements/issues/new?assignees"
+                    "=&labels=bug&template=bug_report.md!"
+                )
 
         _LOGGER.info(f"Notebook path: {nb_path}")
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab_requirements",
-  "version": "0.10.9",
+  "version": "0.11.0",
   "description": "JupyterLab Extension for dependency management and optimization",
   "keywords": [
     "jupyter",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,6 @@ import {
 import { Kernel } from '@jupyterlab/services';
 import { IMainMenu } from '@jupyterlab/mainmenu';
 import { ICommandPalette } from '@jupyterlab/apputils';
-import { Menu } from '@lumino/widgets';
 import { INotification } from "jupyterlab_toastify";
 
 // Customizations
@@ -265,7 +264,7 @@ async function activate(
     }
 
     // Add button in main menu
-    const command = 'dependencies:kernel';
+    const command = commandIDs.kernelHandler;;
 
     function createPanel(): KernelHandler {
       const menu_extension = new KernelHandler();
@@ -274,8 +273,8 @@ async function activate(
 
     // Add a command
     commands.addCommand(command, {
-      label: 'Kernel delete...',
-      caption: 'Kernel delete...',
+      label: 'Delete Kernel...',
+      caption: 'Delete Kernel...',
       execute: (args: any) => {
         createPanel();
       }
@@ -289,14 +288,11 @@ async function activate(
       args: { origin: 'from the palette' }
     });
 
-    // Create a menu
-    // TODO: Move to Kernel Group menu
-    const tutorialMenu: Menu = new Menu({ commands });
-    tutorialMenu.title.label = 'Dependencies';
-    mainMenu.addMenu(tutorialMenu, { rank: 80 });
+    if ( mainMenu ) {
+      // Add command to Kernel Group
+      mainMenu.kernelMenu.addGroup( [{ command }], 30 )
+    }
 
-    // Add the command to the menu
-    tutorialMenu.addItem({ command, args: { origin: 'from the menu' } });
 };
 
 namespace ThothPrivate {


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Thanks to JupyterLab team help (cc @fcollonval ), we moved the command on the menu to the correct group.

Fixes: https://github.com/thoth-station/jupyterlab-requirements/issues/335

![Screenshot from 2021-09-07 17-14-02](https://user-images.githubusercontent.com/27498679/132369622-718abd58-d8aa-4138-837e-7d477ca1bbbd.png)
