### PR TITLE
Update the labels for the bug and feature templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-labels: bug
+labels: kind/bug
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-labels: enhancement
+labels: kind/feature
 ---
 
 **Is your feature request related to a problem? Please describe.**


### PR DESCRIPTION

## This Pull Request implements

The issue templates for bugs  and features still had the old labels "bug" and "enhancement".

The current version of these is  "kind/bug" and "kind/feature" respectively.
